### PR TITLE
Modern bravefile syntax

### DIFF
--- a/alpine/alpine-datascience/Bravefile
+++ b/alpine/alpine-datascience/Bravefile
@@ -1,3 +1,4 @@
+image: alpine-python-pandas-sklearn/1.0
 base:
   image: alpine/edge/amd64
   location: public
@@ -12,10 +13,8 @@ packages:
   - py3-scikit-learn
   - ipython
 service:
-  image: alpine-python-pandas-sklearn-1.0
   name: alpine-python-pandas-sklearn
   docker: "no"
-  version: "1.0"
   ports:
   - ""
   resources:

--- a/alpine/alpine-datascience/Bravefile
+++ b/alpine/alpine-datascience/Bravefile
@@ -15,8 +15,6 @@ packages:
 service:
   name: alpine-python-pandas-sklearn
   docker: "no"
-  ports:
-  - ""
   resources:
     ram: 2GB
     cpu: 2

--- a/alpine/alpine-edge-complib/Bravefile
+++ b/alpine/alpine-edge-complib/Bravefile
@@ -22,8 +22,6 @@ service:
   name: alpine-edge-complib
   docker: "no"
   ip: ""
-  ports:
-  - ""
   resources:
     ram: 2GB
     cpu: 2

--- a/alpine/alpine-edge-complib/Bravefile
+++ b/alpine/alpine-edge-complib/Bravefile
@@ -1,3 +1,4 @@
+image: alpine-edge-complib/1.0
 base:
   image: alpine/edge/amd64
   location: public
@@ -18,10 +19,8 @@ packages:
   - libstdc++
   - libgomp
 service:
-  image: alpine-edge-complib-1.0
   name: alpine-edge-complib
   docker: "no"
-  version: "1.0"
   ip: ""
   ports:
   - ""

--- a/alpine/alpine-edge-mlbase/Bravefile
+++ b/alpine/alpine-edge-mlbase/Bravefile
@@ -1,3 +1,4 @@
+image: alpine-edge-mlbase/1.0
 base:
   image: alpine/edge/amd64
   location: public
@@ -111,9 +112,7 @@ run:
   - --py
   - widgetsnbextension
 service:
-  image: alpine-edge-mlbase-1.0
   name: alpine-edge-mlbase
-  version: "1.0"
   ip: ""
   ports: []
   resources:

--- a/alpine/alpine-edge-mlcore/Bravefile
+++ b/alpine/alpine-edge-mlcore/Bravefile
@@ -1,3 +1,4 @@
+image: alpine-edge-mlcore/1.0
 base:
   image: beringresearch/bravefiles/alpine/alpine-edge-complib
   location: github
@@ -18,10 +19,8 @@ run:
   - notebook
   - matplotlib
 service:
-  image: alpine-edge-mlcore-1.0
   name: alpine-edge-mlcore
   docker: "no"
-  version: "1.0"
   ip: ""
   ports: []
   resources:

--- a/apps/airflow/Bravefile
+++ b/apps/airflow/Bravefile
@@ -1,3 +1,4 @@
+image: airflow/1.0
 base:
   image: ubuntu/focal/amd64
   location: public
@@ -20,10 +21,8 @@ run:
   - airflow users create --username admin --password admin --firstname admin --lastname
     admin --role Admin --email admin@admin.com
 service:
-  image: airflow-1.0
   name: airflow
   docker: "no"
-  version: "1.0"
   ports:
   - 8080:8080
   resources:

--- a/apps/code-server/Bravefile
+++ b/apps/code-server/Bravefile
@@ -1,3 +1,4 @@
+image: code-server/1.0
 base:
   image: ubuntu/focal/amd64
   location: public
@@ -15,10 +16,8 @@ run:
   - -c
   - systemctl enable --now code-server@$USER
 service:
-  image: code-server-1.0
   name: code-server
   docker: "no"
-  version: "1.0"
   ports:
   - 8080:8080
   resources:

--- a/apps/detectron2/Bravefile
+++ b/apps/detectron2/Bravefile
@@ -1,3 +1,4 @@
+image: detectron-cpu/1.0
 base:
   image: beringresearch/bravefiles/ubuntu/ubuntu-bionic-mlbase
   location: github
@@ -34,9 +35,7 @@ run:
     python3 -m pip install detectron2 -f \
       https://dl.fbaipublicfiles.com/detectron2/wheels/cpu/torch1.6/index.html
 service:
-  image: detectron-cpu-1.0
   name: detectron-cpu
-  version: "1.0"
   ip: 10.0.0.10
   ports:
   - 8888:8888

--- a/apps/ftp-server/Bravefile
+++ b/apps/ftp-server/Bravefile
@@ -1,3 +1,4 @@
+image: vsftp/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -28,10 +29,8 @@ copy:
   target: /etc/
   action: sudo chown root /etc/vsftpd.conf
 service:
-  image: vsftp-1.0
   name: vsftp
   docker: "no"
-  version: "1.0"
   ip: 10.0.0.12
   ports:
   - "21:21"

--- a/apps/go-1.16.4/Bravefile
+++ b/apps/go-1.16.4/Bravefile
@@ -1,3 +1,4 @@
+image: go/1.16.4
 base:
   image: ubuntu/focal/amd64
   location: public
@@ -33,10 +34,8 @@ run:
   - -c
   - rm go1.16.4.linux-amd64.tar.gz
 service:
-  image: go-1.16.4
   name: go
   docker: "no"
-  version: 1.16.4
   resources:
     ram: 4GB
     cpu: 2

--- a/apps/gpt2-streamlit/Bravefile
+++ b/apps/gpt2-streamlit/Bravefile
@@ -1,3 +1,4 @@
+image: gpt2-streamlit/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -30,10 +31,8 @@ copy:
 - source: supervisord.conf
   target: /etc/supervisor/conf.d/
 service:
-  image: gpt2-streamlit-1.0
   name: gpt2-streamlit
   docker: "no"
-  version: "1.0"
   ip: ""
   ports:
   - 8501:8501

--- a/apps/label-studio/Bravefile
+++ b/apps/label-studio/Bravefile
@@ -1,3 +1,4 @@
+image: label-studio/1.0
 base:
   image: ubuntu/focal/amd64
   location: public
@@ -15,10 +16,8 @@ run:
   - -c
   - python3 -m pip install label-studio
 service:
-  image: label-studio-1.0
   name: label-studio
   docker: "no"
-  version: "1.0"
   ports:
   - 8080:8080
   resources:

--- a/apps/mlflow/Bravefile
+++ b/apps/mlflow/Bravefile
@@ -1,3 +1,4 @@
+image: mlflow/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -25,10 +26,8 @@ copy:
 - source: mlflow-server.conf
   target: /etc/supervisor/conf.d
 service:
-  image: mlflow-1.0
   name: mlflow
   docker: "no"
-  version: "1.0"
   ip: 10.0.0.11
   ports:
   - 4040:4040

--- a/apps/revealjs/Bravefile
+++ b/apps/revealjs/Bravefile
@@ -1,3 +1,4 @@
+image: revealjs/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -26,10 +27,8 @@ run:
   - -c
   - git clone https://github.com/hakimel/reveal.js.git && cd reveal.js && npm install
 service:
-  image: revealjs-1.0
   name: revealjs
   docker: "no"
-  version: "1.0"
   ip: ""
   ports:
   - 8000:8000

--- a/apps/ubuntu-bionic-vott/Bravefile
+++ b/apps/ubuntu-bionic-vott/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-vott/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -33,8 +34,6 @@ run:
     npm ci
 service:
   name: ubuntu-bionic-vott
-  image: ubuntu-bionic-vott-1.0
-  version: "1.0"
   ip: ""
   ports:
   - 3000:3000

--- a/apps/ubuntu-bionic-vott/Bravefile
+++ b/apps/ubuntu-bionic-vott/Bravefile
@@ -33,6 +33,7 @@ run:
     npm ci
 service:
   name: ubuntu-bionic-vott
+  image: ubuntu-bionic-vott-1.0
   version: "1.0"
   ip: ""
   ports:

--- a/debian/debian-buster-ivis-master/Bravefile
+++ b/debian/debian-buster-ivis-master/Bravefile
@@ -1,3 +1,4 @@
+image: debian-buster-ivis-master/1.0
 base:
   image: debian/buster/amd64
   location: public
@@ -34,10 +35,8 @@ copy:
 - source: jupyter-server.conf
   target: /etc/supervisor/conf.d
 service:
-  image: debian-buster-ivis-master-1.0
   name: debian-buster-ivis-master
   docker: "no"
-  version: "1.0"
   ip: ""
   ports:
   - 8888:8888

--- a/debian/mlbase/Bravefile
+++ b/debian/mlbase/Bravefile
@@ -1,3 +1,4 @@
+image: brave-mlbase/1.0
 base:
   image: debian/buster/amd64
   location: public
@@ -27,10 +28,8 @@ run:
     numpy pandas scikit-learn matplotlib \
     tensorflow ipython notebook ivis shap
 service:
-  image: brave-mlbase-1.0
   name: brave-mlbase
   docker: "no"
-  version: "1.0"
   ip: ""
   ports: []
   resources:

--- a/ubuntu/ubuntu-bionic-cuda101/Bravefile
+++ b/ubuntu/ubuntu-bionic-cuda101/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-cuda-101/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -53,10 +54,8 @@ run:
   - -c
   - echo "export LD_LIBRARY_PATH=/usr/local/cuda-10.2/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH" >> ~/.bashrc
 service:
-  image: ubuntu-bionic-cuda-101-1.0
   name: ubuntu-bionic-cuda-101
   docker: "no"
-  version: "1.0"
   ip: ""
   ports: []
   resources:

--- a/ubuntu/ubuntu-bionic-cuda110/Bravefile
+++ b/ubuntu/ubuntu-bionic-cuda110/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-cuda110/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -90,10 +91,8 @@ run:
   - -c
   - rm *.deb
 service:
-  image: ubuntu-bionic-cuda110-1.0
   name: ubuntu-bionic-cuda110
   docker: "no"
-  version: "1.0"
   resources:
     ram: 4GB
     cpu: 2

--- a/ubuntu/ubuntu-bionic-cuda111/Bravefile
+++ b/ubuntu/ubuntu-bionic-cuda111/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-cuda110/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -90,10 +91,8 @@ run:
   - -c
   - rm *.deb
 service:
-  image: ubuntu-bionic-cuda110-1.0
   name: ubuntu-bionic-cuda110
   docker: "no"
-  version: "1.0"
   resources:
     ram: 4GB
     cpu: 2

--- a/ubuntu/ubuntu-bionic-docker/Bravefile
+++ b/ubuntu/ubuntu-bionic-docker/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-docker/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -31,10 +32,8 @@ run:
   - -c
   - apt-get install -y docker-ce docker-ce-cli containerd.io
 service:
-  image: ubuntu-bionic-docker-1.0
   name: ubuntu-bionic-docker
   docker: "yes"
-  version: "1.0"
   resources:
     ram: 8GB
     cpu: 4

--- a/ubuntu/ubuntu-bionic-fairseq/Bravefile
+++ b/ubuntu/ubuntu-bionic-fairseq/Bravefile
@@ -45,6 +45,7 @@ run:
     sacremoses
 service:
   name: fairseq
+  image: fairseq-1.0
   version: "1.0"
   ip: 10.0.0.10
   ports:

--- a/ubuntu/ubuntu-bionic-fairseq/Bravefile
+++ b/ubuntu/ubuntu-bionic-fairseq/Bravefile
@@ -1,3 +1,4 @@
+image: fairseq/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -45,8 +46,6 @@ run:
     sacremoses
 service:
   name: fairseq
-  image: fairseq-1.0
-  version: "1.0"
   ip: 10.0.0.10
   ports:
   - 8888:8888

--- a/ubuntu/ubuntu-bionic-gpu/Bravefile
+++ b/ubuntu/ubuntu-bionic-gpu/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-gpu/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -6,10 +7,8 @@ packages:
   system:
   - bash
 service:
-  image: ubuntu-bionic-gpu-1.0
   name: ubuntu-bionic-gpu
   docker: "no"
-  version: "1.0"
   ip: ""
   ports: []
   resources:

--- a/ubuntu/ubuntu-bionic-microk8s/Bravefile
+++ b/ubuntu/ubuntu-bionic-microk8s/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-microk8s/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -40,10 +41,8 @@ run:
   - service
   - microbot-service
 service:
-  image: ubuntu-bionic-microk8s-1.0
   name: ubuntu-bionic-microk8s
   docker: "yes"
-  version: "1.0"
   ip: ""
   ports:
   - ""

--- a/ubuntu/ubuntu-bionic-microk8s/Bravefile
+++ b/ubuntu/ubuntu-bionic-microk8s/Bravefile
@@ -44,8 +44,6 @@ service:
   name: ubuntu-bionic-microk8s
   docker: "yes"
   ip: ""
-  ports:
-  - ""
   resources:
     ram: 4GB
     cpu: 2

--- a/ubuntu/ubuntu-bionic-miniconda3/Bravefile
+++ b/ubuntu/ubuntu-bionic-miniconda3/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-miniconda3/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -17,8 +18,6 @@ run:
   - $HOME/miniconda
 service:
   name: ubuntu-bionic-miniconda3
-  image: ubuntu-bionic-miniconda3-1.0
-  version: "1.0"
   ip: ""
   ports: []
   resources:

--- a/ubuntu/ubuntu-bionic-miniconda3/Bravefile
+++ b/ubuntu/ubuntu-bionic-miniconda3/Bravefile
@@ -17,6 +17,7 @@ run:
   - $HOME/miniconda
 service:
   name: ubuntu-bionic-miniconda3
+  image: ubuntu-bionic-miniconda3-1.0
   version: "1.0"
   ip: ""
   ports: []

--- a/ubuntu/ubuntu-bionic-mlbase-cuda/Bravefile
+++ b/ubuntu/ubuntu-bionic-mlbase-cuda/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-mlbase-cuda/1.0
 base:
   image: ubuntu-bionic-cuda-101-1.0
   location: local
@@ -59,9 +60,7 @@ run:
   - -c
   - jupyter notebook --generate-config
 service:
-  image: ubuntu-bionic-mlbase-cuda-1.0
   name: ubuntu-bionic-mlbase-cuda
-  version: "1.0"
   ip: ""
   ports:
   - 8888:8888

--- a/ubuntu/ubuntu-bionic-mlbase/Bravefile
+++ b/ubuntu/ubuntu-bionic-mlbase/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-mlbase/1.0
 base:
   image: ubuntu/focal/amd64
   location: public
@@ -60,9 +61,7 @@ copy:
 - source: jupyter-server.conf
   target: /etc/supervisor/conf.d
 service:
-  image: ubuntu-bionic-mlbase-1.0
   name: ubuntu-bionic-mlbase
-  version: "1.0"
   ports:
   - 8888:8888
   resources:

--- a/ubuntu/ubuntu-bionic-py3/Bravefile
+++ b/ubuntu/ubuntu-bionic-py3/Bravefile
@@ -25,6 +25,7 @@ run:
   - matplotlib
 service:
   name: ubuntu-bionic-py3
+  image: ubuntu-bionic-py3-1.0
   version: "1.0"
   ip: ""
   ports: []

--- a/ubuntu/ubuntu-bionic-py3/Bravefile
+++ b/ubuntu/ubuntu-bionic-py3/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-py3/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -25,8 +26,6 @@ run:
   - matplotlib
 service:
   name: ubuntu-bionic-py3
-  image: ubuntu-bionic-py3-1.0
-  version: "1.0"
   ip: ""
   ports: []
   resources:

--- a/ubuntu/ubuntu-bionic-pytorch/Bravefile
+++ b/ubuntu/ubuntu-bionic-pytorch/Bravefile
@@ -40,6 +40,7 @@ run:
   - /root/.local/bin/pip install --user ipython pandas notebook scikit-learn matplotlib
 service:
   name: pytorch
+  image: pytorch-1.5
   version: "1.5"
   ip: ""
   ports: []

--- a/ubuntu/ubuntu-bionic-pytorch/Bravefile
+++ b/ubuntu/ubuntu-bionic-pytorch/Bravefile
@@ -1,3 +1,4 @@
+image: pytorch/1.5
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -40,8 +41,6 @@ run:
   - /root/.local/bin/pip install --user ipython pandas notebook scikit-learn matplotlib
 service:
   name: pytorch
-  image: pytorch-1.5
-  version: "1.5"
   ip: ""
   ports: []
   resources:

--- a/ubuntu/ubuntu-bionic-r/Bravefile
+++ b/ubuntu/ubuntu-bionic-r/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-r/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -53,9 +54,7 @@ run:
   - -c
   - Rscript -e 'install.packages(c("Seurat", "dplyr"))'
 service:
-  image: ubuntu-bionic-r-1.0
   name: ubuntu-bionic-r
-  version: "1.0"
   ip: ""
   ports: []
   resources:

--- a/ubuntu/ubuntu-bionic-rstudio-server/Bravefile
+++ b/ubuntu/ubuntu-bionic-rstudio-server/Bravefile
@@ -1,3 +1,4 @@
+image: rstudio/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -56,10 +57,8 @@ run:
   - -c
   - sudo adduser rstudio
 service:
-  image: rstudio-1.0
   name: rstudio
   docker: "no"
-  version: "1.0"
   ports:
   - 8787:8787
   resources:

--- a/ubuntu/ubuntu-bionic-vim/Bravefile
+++ b/ubuntu/ubuntu-bionic-vim/Bravefile
@@ -36,6 +36,7 @@ run:
   - /dev/null
 service:
   name: ubuntu-bionic-vim
+  image: ubuntu-bionic-vim-1.0
   version: "1.0"
   ip: ""
   ports: []

--- a/ubuntu/ubuntu-bionic-vim/Bravefile
+++ b/ubuntu/ubuntu-bionic-vim/Bravefile
@@ -1,3 +1,4 @@
+image: ubuntu-bionic-vim/1.0
 base:
   image: ubuntu/bionic/amd64
   location: public
@@ -36,8 +37,6 @@ run:
   - /dev/null
 service:
   name: ubuntu-bionic-vim
-  image: ubuntu-bionic-vim-1.0
-  version: "1.0"
   ip: ""
   ports: []
   resources:


### PR DESCRIPTION
This PR updates all Bravefiles to use modern syntax utilized in bravetools 2.0. The Image name is declared at the top of the file and contains the version.

Bravefiles that were missing the image field entirely were found and corrected.

Empty port strings do not pass validation checks in bravetools 2.0 and so are not allowed - these are also stripped out.